### PR TITLE
Level balancing and fixes

### DIFF
--- a/EnchantedGarden/Assets/Prefabs/Environment/Forest Edge.prefab
+++ b/EnchantedGarden/Assets/Prefabs/Environment/Forest Edge.prefab
@@ -28,7 +28,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1207844894}
   m_LocalRotation: {x: 0, y: 0.46174863, z: 0, w: 0.8870109}
-  m_LocalPosition: {x: -14.77, y: 1, z: -26.72}
+  m_LocalPosition: {x: -16.53, y: 1, z: -25.97}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -135,7 +135,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1277104907}
   m_LocalRotation: {x: 0, y: -0.38268343, z: 0, w: 0.92387956}
-  m_LocalPosition: {x: -13.32, y: 1, z: 14.79}
+  m_LocalPosition: {x: -14.9, y: 1, z: 14.2}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -242,7 +242,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1635368041}
   m_LocalRotation: {x: 0, y: -0.46174863, z: 0, w: 0.8870109}
-  m_LocalPosition: {x: 6.97, y: 1, z: -26.17}
+  m_LocalPosition: {x: 8.27, y: 1, z: -25.46}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -349,7 +349,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2077317123}
   m_LocalRotation: {x: 0, y: 0.38268343, z: 0, w: 0.92387956}
-  m_LocalPosition: {x: 5.42, y: 1, z: 15.05}
+  m_LocalPosition: {x: 6.31, y: 1, z: 15.19}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -527,7 +527,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6069096460742581489}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.96, y: 1, z: -32.2}
+  m_LocalPosition: {x: -2.96, y: 1, z: -32.9}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -634,7 +634,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7350897773459051242}
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -21, y: 1, z: -5.26}
+  m_LocalPosition: {x: -21.9, y: 1, z: -5.26}
   m_LocalScale: {x: 25, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -741,7 +741,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7509603680254921868}
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 13.37, y: 1, z: -4.84}
+  m_LocalPosition: {x: 14, y: 1, z: -4.84}
   m_LocalScale: {x: 25, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}
@@ -848,7 +848,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7858873746374927926}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.04, y: 1, z: 17.36}
+  m_LocalPosition: {x: -4.04, y: 1, z: 18.2}
   m_LocalScale: {x: 23, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1664038717420124773}

--- a/EnchantedGarden/Assets/Prefabs/Interactable/Cauldron/Cauldron.prefab
+++ b/EnchantedGarden/Assets/Prefabs/Interactable/Cauldron/Cauldron.prefab
@@ -338,7 +338,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.21}
   m_SizeDelta: {x: 1.2, y: 1.2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4468563092947773425

--- a/EnchantedGarden/Assets/Scenes/Subscenes/Level Failed.unity
+++ b/EnchantedGarden/Assets/Scenes/Subscenes/Level Failed.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -151,11 +151,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 767529250}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -52}
+  m_AnchoredPosition: {x: 0, y: -25}
   m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &131058238
@@ -286,8 +286,9 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1531456785}
-  - {fileID: 2027942342}
   - {fileID: 131058237}
+  - {fileID: 1804842226}
+  - {fileID: 2027942342}
   m_Father: {fileID: 1496683090}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -393,6 +394,7 @@ GameObject:
   - component: {fileID: 1496683090}
   - component: {fileID: 1496683089}
   - component: {fileID: 1496683091}
+  - component: {fileID: 1496683092}
   m_Layer: 0
   m_Name: UI Manager
   m_TagString: Untagged
@@ -441,6 +443,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _focusButton: {fileID: 2027942344}
+--- !u!114 &1496683092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1496683088}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 137931d6aa1ccd74ab7f3711e3f06262, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _notEnoughPointsText: {fileID: 1804842227}
 --- !u!1 &1531456784
 GameObject:
   m_ObjectHideFlags: 0
@@ -574,6 +589,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1531456784}
   m_CullTransparentMesh: 0
+--- !u!1 &1804842225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1804842226}
+  - component: {fileID: 1804842228}
+  - component: {fileID: 1804842227}
+  m_Layer: 5
+  m_Name: Not Enough Points
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1804842226
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804842225}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9988291, y: 0.9988291, z: 0.9988291}
+  m_Children: []
+  m_Father: {fileID: 767529250}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -3.9952846, y: -224.77051}
+  m_SizeDelta: {x: 500, y: 132.51767}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1804842227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804842225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: You didn't score enough points
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 0f99c98eb963e2f40999f70dba7ec888, type: 2}
+  m_sharedMaterial: {fileID: 6532412222534340129, guid: 0f99c98eb963e2f40999f70dba7ec888,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4291570094
+  m_fontColor: {r: 0.6838024, g: 0.16264686, b: 0.8018868, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 61.75
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 36
+  m_fontSizeMax: 108
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -99.668045, y: 36.955505, z: -107.97125, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1804842228
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804842225}
+  m_CullTransparentMesh: 0
 --- !u!1001 &2027942341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -624,7 +773,7 @@ PrefabInstance:
     - target: {fileID: 1100114420727354417, guid: 489c6aee211b44414872f7afdf05d7a5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1100114420727354417, guid: 489c6aee211b44414872f7afdf05d7a5,
         type: 3}

--- a/EnchantedGarden/Assets/ScriptableData/GameData/Level 2 Data.asset
+++ b/EnchantedGarden/Assets/ScriptableData/GameData/Level 2 Data.asset
@@ -17,9 +17,9 @@ MonoBehaviour:
   _infiniteLevel: 0
   _oneStarScoreThreshold: 12000
   _twoStarScoreThreshold: 25000
-  _threeStarScoreThreshold: 42000
+  _threeStarScoreThreshold: 40000
   _waves:
-  - Count: 3
+  - Count: 2
     WaveDelay: 20
     SpiritSpawnDelay: 3
     MoveSpeedMultiplier: 1
@@ -34,11 +34,6 @@ MonoBehaviour:
     SpiritSpawnDelay: 3
     MoveSpeedMultiplier: 1
     PossessionRateMultiplier: 0.5
-  - Count: 1
-    WaveDelay: 10
-    SpiritSpawnDelay: 3
-    MoveSpeedMultiplier: 1
-    PossessionRateMultiplier: 0.75
   - Count: 3
     WaveDelay: 30
     SpiritSpawnDelay: 3
@@ -49,8 +44,13 @@ MonoBehaviour:
     SpiritSpawnDelay: 3
     MoveSpeedMultiplier: 1
     PossessionRateMultiplier: 1
+  - Count: 1
+    WaveDelay: 10
+    SpiritSpawnDelay: 3
+    MoveSpeedMultiplier: 1
+    PossessionRateMultiplier: 1
   _unplantedFactor: 2
-  _possessionThreshold: 10
+  _possessionThreshold: 11
   _startNumberOfPlants: 5
   _replantingThreshold: 1
   _cauldronSettings:
@@ -60,4 +60,4 @@ MonoBehaviour:
     _fireDuration: 45
   _backgroundMusic: {fileID: 11400000, guid: 5709d1f359cc8494cb9d499d0b752e16, type: 2}
   _midIntensityMusicThreshold: 3
-  _highIntensityMusicThreshold: 5
+  _highIntensityMusicThreshold: 4

--- a/EnchantedGarden/Assets/ScriptableData/GameData/Level 3 Data.asset
+++ b/EnchantedGarden/Assets/ScriptableData/GameData/Level 3 Data.asset
@@ -15,11 +15,11 @@ MonoBehaviour:
   _level: 4
   _levelDuration: 180
   _infiniteLevel: 0
-  _oneStarScoreThreshold: 20000
-  _twoStarScoreThreshold: 30000
-  _threeStarScoreThreshold: 50000
+  _oneStarScoreThreshold: 19000
+  _twoStarScoreThreshold: 28000
+  _threeStarScoreThreshold: 48000
   _waves:
-  - Count: 4
+  - Count: 3
     WaveDelay: 10
     SpiritSpawnDelay: 2
     MoveSpeedMultiplier: 1
@@ -44,7 +44,7 @@ MonoBehaviour:
     SpiritSpawnDelay: 2
     MoveSpeedMultiplier: 1
     PossessionRateMultiplier: 0.5
-  - Count: 4
+  - Count: 3
     WaveDelay: 25
     SpiritSpawnDelay: 2
     MoveSpeedMultiplier: 1
@@ -55,14 +55,14 @@ MonoBehaviour:
     MoveSpeedMultiplier: 1
     PossessionRateMultiplier: 0.75
   _unplantedFactor: 2
-  _possessionThreshold: 9
+  _possessionThreshold: 11
   _startNumberOfPlants: 4
   _replantingThreshold: 1
   _cauldronSettings:
-    _startNumberOfUses: 5
-    _maximumUses: 5
-    _startFireDuration: 70
-    _fireDuration: 70
+    _startNumberOfUses: 6
+    _maximumUses: 6
+    _startFireDuration: 75
+    _fireDuration: 75
   _backgroundMusic: {fileID: 11400000, guid: 9a0fb136280056e4fbb7cfb96a015c3c, type: 2}
-  _midIntensityMusicThreshold: 3
-  _highIntensityMusicThreshold: 5
+  _midIntensityMusicThreshold: 4
+  _highIntensityMusicThreshold: 6

--- a/EnchantedGarden/Assets/Scripts/Interactible/Cauldron.cs
+++ b/EnchantedGarden/Assets/Scripts/Interactible/Cauldron.cs
@@ -130,7 +130,8 @@ public class Cauldron : MonoBehaviour, IInteractable
 
 	private IEnumerator CauldronCombineCoroutine()
 	{
-		AudioController.PlayAudio(_cauldronAudioSource, _cauldronCombineAudio);
+		// Combine noise as detached audio source so it will finish playing even if the cauldron is not useable
+		AudioController.PlayAudioDetached(_cauldronCombineAudio, transform.position);
 		yield return new WaitForSeconds(_cauldronCombineAudio.clip.length * 0.8f);
 		AudioController.PlayAudio(_cauldronAudioSource, _cauldronBubbleAudio);
 	}

--- a/EnchantedGarden/Assets/Scripts/Interactible/Plant.cs
+++ b/EnchantedGarden/Assets/Scripts/Interactible/Plant.cs
@@ -132,9 +132,10 @@ public class Plant : PickUpBase, IPossessable, IInteractable
 
 	public override bool CanBePickedUp => _plantState == PlantState.Default && !_planted && _plantPatch == null;
 
-	public override bool CanBeDropped => base.CanBeDropped
+	// Allow plant to be dropped anywhere
+	/*public override bool CanBeDropped => base.CanBeDropped
 									&& Physics.OverlapSphere(transform.position, 2.0f).Where(c => c.GetComponent<PlantPatch>() != null
-									&& !c.GetComponent<PlantPatch>().ContainsPlant).ToList().Count > 0;
+									&& !c.GetComponent<PlantPatch>().ContainsPlant).ToList().Count > 0;*/
 
 	public override void OnPickUp(Transform pickupTransform)
 	{
@@ -154,7 +155,6 @@ public class Plant : PickUpBase, IPossessable, IInteractable
 	public override void OnDrop(bool despawn = false)
 	{
 		base.OnDrop();
-		//	TODO: All of this can be done with Trigger Collider and Layers
 		var plantPatch = GetNearbyPlantPatch();
 
 		if (plantPatch != null)

--- a/EnchantedGarden/Assets/Scripts/UI/UiLevelFailed.cs
+++ b/EnchantedGarden/Assets/Scripts/UI/UiLevelFailed.cs
@@ -1,0 +1,14 @@
+﻿using TMPro;
+using UnityEngine;
+
+public class UiLevelFailed : MonoBehaviour
+{
+    [SerializeField]
+    private TMP_Text _notEnoughPointsText;
+
+    // Start is called before the first frame update
+    private void Start()
+    {
+        _notEnoughPointsText.gameObject.SetActive(GameManager.Instance.ActiveLevel.CurrentNumberOfPlants > 0);
+    }       
+}

--- a/EnchantedGarden/Assets/Scripts/UI/UiLevelFailed.cs.meta
+++ b/EnchantedGarden/Assets/Scripts/UI/UiLevelFailed.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 137931d6aa1ccd74ab7f3711e3f06262
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EnchantedGarden/Assets/Scripts/UI/UiVictory.cs
+++ b/EnchantedGarden/Assets/Scripts/UI/UiVictory.cs
@@ -45,6 +45,6 @@ public class UiVictory : MonoBehaviour
 
 		Debug.Log($"Playing audio: {_sceneMusic.name}");
 		//	Play Scene Audio loop
-		AudioController.PlayAudio(_backgroundMusicAudioSource, _sceneMusic);
+		//AudioController.PlayAudio(_backgroundMusicAudioSource, _sceneMusic);
 	}
 }


### PR DESCRIPTION
- Balanced levels 2 and 3 in response to playtest feedback.
- Fixed cauldron combine sound cutting out when filling a flask uses the last potion dose.
- Moved the edge of forest colliders to better align with the forests position.
- Changed plant to allow it to be dropped anywhere.
- Added text to level failed screen to indicate if the player failed because they didn't get enough points.
- Fixed cauldron not usable sign blocking cannot add ingredient sign.